### PR TITLE
fix: only check version against tag, if triggered by a tag

### DIFF
--- a/.github/workflows/docker-ghcr-cd.yml
+++ b/.github/workflows/docker-ghcr-cd.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   check-version:
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v4
       - name: Check version matches tag


### PR DESCRIPTION
We only need to check the Cargo.toml version if we create a new release and the workflow is triggered by the tag. 
The workflow can also be triggered by a push on main, which obviously has nothing to check. 

The check is a safety mechanism that we don't forget updating the version in the Cargo.toml before creating a release.